### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## 1.2.0
 - Added a hash map-based `ruleMap` to `SuffixRules` to speed up the performance when matching rules.
 - Added `subdomain` and `icannSubdomain` to `PublicSuffix`.
+- Added `isSubdomainOf`, `hasKnownSuffix` and `hasValidDomain` to `PublicSuffix`.
+- Added `DomainUtils` with the following static functions:
+    - `isSubdomainOf`
+    - `isSubdomain`
+    - `isKnownSuffix`
+    - `hasValidDomain`
 
 ## 1.1.0
 - Added primary library `public_suffix.dart`, which can be used without `dart:io` and `dart:html` (but still requires to be initialised with a suffix list).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     - `isSubdomain`
     - `isKnownSuffix`
     - `hasValidDomain`
+- Added `PublicSuffix.fromString` as a convenience method for `PublicSuffix(Uri.parse(string))`.
+- Updated docs and parameter names to say URL instead of URI, which is more correct (`PublicSuffix.sourceUri` is unchanged to avoid breaking changes).
 
 ## 1.1.0
 - Added primary library `public_suffix.dart`, which can be used without `dart:io` and `dart:html` (but still requires to be initialised with a suffix list).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+- Added a hash map-based `ruleMap` to `SuffixRules` to speed up the performance when matching rules.
+- Added `subdomain` and `icannSubdomain` to `PublicSuffix`.
+
 ## 1.1.0
 - Added primary library `public_suffix.dart`, which can be used without `dart:io` and `dart:html` (but still requires to be initialised with a suffix list).
 

--- a/lib/public_suffix.dart
+++ b/lib/public_suffix.dart
@@ -10,3 +10,4 @@
 
 export 'src/public_suffix_base.dart';
 export 'src/suffix_rules.dart';
+export 'src/utilities.dart';

--- a/lib/src/browser/suffix_rules_helper.dart
+++ b/lib/src/browser/suffix_rules_helper.dart
@@ -54,7 +54,7 @@ class SuffixRulesHelper {
         object = e.target;
       }
 
-      if (e is HttpRequest) {
+      if (object is HttpRequest) {
         throw Exception(
             "Request for public suffix list failed: [${object.status}] ${object.statusText}");
       } else {

--- a/lib/src/io/suffix_rules_helper.dart
+++ b/lib/src/io/suffix_rules_helper.dart
@@ -46,14 +46,17 @@ class SuffixRulesHelper {
   }
 
   static Future<void> _initFromUrl(Uri uri) async {
-    try {
-      var request = await HttpClient().getUrl(uri);
-      var response = await request.close();
-      var data = await response.transform(Utf8Decoder()).join();
+    var request = await HttpClient().getUrl(uri);
+    var response = await request.close();
 
-      SuffixRules.initFromString(data);
-    } catch (e) {
-      rethrow;
+    switch (response.statusCode) {
+      case 200:
+        var data = await response.transform(Utf8Decoder()).join();
+        SuffixRules.initFromString(data);
+        break;
+      default:
+        throw Exception(
+            "Request for public suffix list failed: [${response.statusCode}]");
     }
   }
 }

--- a/lib/src/public_suffix_base.dart
+++ b/lib/src/public_suffix_base.dart
@@ -160,6 +160,12 @@ class PublicSuffix {
     _parseUri(sourceUri, SuffixRules.ruleMap);
   }
 
+  /// Creates a new instance from a URI in a string.
+  ///
+  /// This is a convenience method that simply converts [uri] into a URI object
+  /// and creates an instance from it.
+  PublicSuffix.fromString(String uri) : this(Uri.parse(uri));
+
   void _parseUri(Uri uri, Map<String, Iterable<Rule>> suffixMap) {
     var host = _decodeHost(uri);
     var matchingRules = _findMatchingRules(host, suffixMap);

--- a/lib/src/public_suffix_base.dart
+++ b/lib/src/public_suffix_base.dart
@@ -94,12 +94,12 @@ class PublicSuffix {
           "The URI is missing the authority component: $sourceUri");
     }
 
-    _parseUri(sourceUri, SuffixRules.rules);
+    _parseUri(sourceUri, SuffixRules.ruleMap);
   }
 
-  void _parseUri(Uri uri, List<Rule> suffixList) {
+  void _parseUri(Uri uri, Map<String, Iterable<Rule>> suffixMap) {
     var host = _decodeHost(uri);
-    var matchingRules = _findMatchingRules(host, suffixList);
+    var matchingRules = _findMatchingRules(host, suffixMap);
     var prevailingIcannRule = _getPrevailingRule(matchingRules['icann']);
     var prevailingAllRule = _getPrevailingRule(matchingRules['all']);
 
@@ -149,16 +149,21 @@ class PublicSuffix {
   }
 
   Map<String, List<Rule>> _findMatchingRules(
-      String host, List<Rule> suffixList) {
+      String host, Map<String, Iterable<Rule>> suffixMap) {
     var icannMatches = <Rule>[];
     var allMatches = <Rule>[];
 
-    for (var rule in suffixList) {
-      if (_ruleMatches(rule, host)) {
-        allMatches.add(rule);
+    var lastLabel = host.substring(host.lastIndexOf(('.')) + 1);
+    var suffixList = suffixMap[lastLabel];
 
-        if (rule.isIcann) {
-          icannMatches.add(rule);
+    if (suffixList != null) {
+      for (var rule in suffixList) {
+        if (_ruleMatches(rule, host)) {
+          allMatches.add(rule);
+
+          if (rule.isIcann) {
+            icannMatches.add(rule);
+          }
         }
       }
     }

--- a/lib/src/public_suffix_base.dart
+++ b/lib/src/public_suffix_base.dart
@@ -89,8 +89,8 @@ class PublicSuffix {
   /// `icann`-prefixed getters.
   bool isPrivateSuffix() => icannSuffix != _suffix;
 
-  PublicSuffix._(this.sourceUri, String host, this._root, this._suffix, this._icannRoot,
-      this._icannSuffix) {
+  PublicSuffix._(this.sourceUri, String host, this._root, this._suffix,
+      this._icannRoot, this._icannSuffix) {
     _domain = _buildRegistrableDomain(_root, _suffix);
     _icannDomain = _buildRegistrableDomain(_icannRoot, _icannSuffix);
     _subdomain = _getSubdomain(host, _domain);
@@ -318,11 +318,16 @@ class PublicSuffix {
   }
 
   String _getSubdomain(String host, String registrableDomain) {
-    if (registrableDomain == null) {
-      return null;
-    } else {
+    var sub;
+
+    if (registrableDomain != null) {
       var index = host.lastIndexOf(registrableDomain);
-      return host.substring(0, index == 0 ? index : index - 1);
+
+      if (index > 0) {
+        sub = host.substring(0, index - 1);
+      }
     }
+
+    return sub;
   }
 }

--- a/lib/src/public_suffix_base.dart
+++ b/lib/src/public_suffix_base.dart
@@ -89,6 +89,29 @@ class PublicSuffix {
   /// `icann`-prefixed getters.
   bool isPrivateSuffix() => icannSuffix != _suffix;
 
+  /// Checks if this object represents a subdomain of another.
+  ///
+  /// The domain and subdomain properties are compared to determine if
+  /// this object represents a subdomain of [other]. If [icann] is [true],
+  /// comparison will be based on only the ICANN/IANA rules.
+  ///
+  /// For example, `http://images.google.co.uk` is a subdomain of `http://google.co.uk`.
+  ///
+  /// If [other] has a subdomain and this object represents a subdomain of that,
+  /// [true] is still returned.
+  bool isSubdomainOf(PublicSuffix other, {bool icann = false}) {
+    if (icann) {
+      return icannDomain == other.icannDomain &&
+          icannSubdomain != null &&
+          (other.icannSubdomain == null ||
+              icannSubdomain.endsWith(other.icannSubdomain));
+    } else {
+      return domain == other.domain &&
+          subdomain != null &&
+          (other.subdomain == null || subdomain.endsWith(other.subdomain));
+    }
+  }
+
   PublicSuffix._(this.sourceUri, String host, this._root, this._suffix,
       this._icannRoot, this._icannSuffix) {
     _domain = _buildRegistrableDomain(_root, _suffix);

--- a/lib/src/public_suffix_base.dart
+++ b/lib/src/public_suffix_base.dart
@@ -95,6 +95,22 @@ class PublicSuffix {
   /// A known suffix is one which has a rule in the suffix rule list.
   bool hasKnownSuffix() => _hasKnownSuffix;
 
+  /// Checks if the registrable domain is valid.
+  ///
+  /// If [icann] is [true] the check will be based on [icannDomain], otherwise
+  /// [domain] is used.
+  /// If [acceptDefaultRule] is [false] URLs with suffixes only matching the
+  /// default rule (`*`) will be seen as invalid.
+  bool hasValidDomain({bool icann = false, bool acceptDefaultRule = true}) {
+    var _domain = (icann ? icannDomain : domain);
+
+    if (acceptDefaultRule || hasKnownSuffix()) {
+      return _domain != null;
+    } else {
+      return false;
+    }
+  }
+
   /// Checks if this object represents a subdomain of another.
   ///
   /// The domain and subdomain properties are compared to determine if

--- a/lib/src/public_suffix_base.dart
+++ b/lib/src/public_suffix_base.dart
@@ -12,7 +12,7 @@ import 'package:punycode/punycode.dart';
 
 import 'suffix_rules.dart';
 
-/// A description of the public suffix, root domain and registrable domain for a URI.
+/// A description of the public suffix, root domain and registrable domain for a URL.
 class PublicSuffix {
   final Uri sourceUri;
 
@@ -29,52 +29,52 @@ class PublicSuffix {
 
   PublicSuffix _punyDecoded;
 
-  /// Returns the registrable domain part of the URI, based on both ICANN/IANA and private rules.
+  /// Returns the registrable domain part of the URL, based on both ICANN/IANA and private rules.
   ///
   /// The registrable domain is the public suffix and one preceding label.
   /// For example, `images.google.co.uk` has the registrable domain `google.co.uk`.
   String get domain => _domain;
 
-  /// Returns the subdomain part of the URI, based on both ICANN/IANA and private rules.
+  /// Returns the subdomain part of the URL, based on both ICANN/IANA and private rules.
   ///
   /// The subdomain is the part of the host that precedes the registrable domain
   /// (see [domain]).
   /// For example, `images.google.co.uk` has the subdomain `images`.
   String get subdomain => _subdomain;
 
-  /// Returns the root domain part of the URI, based on both ICANN/IANA and private rules.
+  /// Returns the root domain part of the URL, based on both ICANN/IANA and private rules.
   ///
   /// The root domain is the label that precedes the public suffix.
   /// For example, `images.google.co.uk` has the root domain `google`.
   String get root => _root;
 
-  /// Returns the public suffix part of the URI, based on both ICANN/IANA and private rules.
+  /// Returns the public suffix part of the URL, based on both ICANN/IANA and private rules.
   ///
   /// The public suffix is the labels at the end of the URL which are not controlled
   /// by the registrant of the domain.
   /// For example, `images.google.co.uk` has the public suffix `co.uk`.
   String get suffix => _suffix;
 
-  /// Returns the registrable domain part of the URI, based on ICANN/IANA rules.
+  /// Returns the registrable domain part of the URL, based on ICANN/IANA rules.
   ///
   /// The registrable domain is the public suffix and one preceding label.
   /// For example, `images.google.co.uk` has the registrable domain `google.co.uk`.
   String get icannDomain => _icannDomain;
 
-  /// Returns the subdomain part of the URI, based on ICANN/IANA rules.
+  /// Returns the subdomain part of the URL, based on ICANN/IANA rules.
   ///
   /// The subdomain is the part of the host that precedes the registrable domain
   /// (see [domain]).
   /// For example, `images.google.co.uk` has the subdomain `images`.
   String get icannSubdomain => _icannSubdomain;
 
-  /// Returns the root domain part of the URI, based on ICANN/IANA rules.
+  /// Returns the root domain part of the URL, based on ICANN/IANA rules.
   ///
   /// The root domain is the label that precedes the public suffix.
   /// For example, `images.google.co.uk` has the root domain `google`.
   String get icannRoot => _icannRoot;
 
-  /// Returns the public suffix part of the URI, based on ICANN/IANA rules.
+  /// Returns the public suffix part of the URL, based on ICANN/IANA rules.
   ///
   /// The public suffix is the labels at the end of the URL which are not controlled
   /// by the registrant of the domain.
@@ -84,7 +84,7 @@ class PublicSuffix {
   /// Returns a punycode decoded version of this object.
   PublicSuffix get punyDecoded => _punyDecoded;
 
-  /// Checks if the URI was matched with a private rule rather than an ICANN/IANA rule.
+  /// Checks if the URL was matched with a private rule rather than an ICANN/IANA rule.
   ///
   /// If [true], then [root], [suffix] and [domain] will be different from the
   /// `icann`-prefixed getters.
@@ -154,20 +154,20 @@ class PublicSuffix {
     }
     if (!sourceUri.hasAuthority) {
       throw ArgumentError(
-          "The URI is missing the authority component: $sourceUri");
+          "The URL is missing the authority component: $sourceUri");
     }
 
-    _parseUri(sourceUri, SuffixRules.ruleMap);
+    _parseUrl(sourceUri, SuffixRules.ruleMap);
   }
 
-  /// Creates a new instance from a URI in a string.
+  /// Creates a new instance from a URL in a string.
   ///
-  /// This is a convenience method that simply converts [uri] into a URI object
+  /// This is a convenience method that simply converts [url] into a URI object
   /// and creates an instance from it.
-  PublicSuffix.fromString(String uri) : this(Uri.parse(uri));
+  PublicSuffix.fromString(String url) : this(Uri.parse(url));
 
-  void _parseUri(Uri uri, Map<String, Iterable<Rule>> suffixMap) {
-    var host = _decodeHost(uri);
+  void _parseUrl(Uri url, Map<String, Iterable<Rule>> suffixMap) {
+    var host = _decodeHost(url);
     var matchingRules = _findMatchingRules(host, suffixMap);
     var prevailingIcannRule = _getPrevailingRule(matchingRules['icann']);
     var prevailingAllRule = _getPrevailingRule(matchingRules['all']);
@@ -200,8 +200,8 @@ class PublicSuffix {
         icannPuny['root'], icannPuny['suffix']);
   }
 
-  String _decodeHost(Uri uri) {
-    var host = uri.host.replaceAll(RegExp(r'\.+$'), '').toLowerCase();
+  String _decodeHost(Uri url) {
+    var host = url.host.replaceAll(RegExp(r'\.+$'), '').toLowerCase();
     host = Uri.decodeComponent(host);
 
     var punycodes = RegExp(r'xn--[a-z0-9-]+').allMatches(host);

--- a/lib/src/suffix_rules.dart
+++ b/lib/src/suffix_rules.dart
@@ -169,9 +169,30 @@ class Rule {
   /// If the rule is an ICANN/IANA rule.
   final bool isIcann;
 
+  List<int> _wildcards;
+
   Rule(String rule, {this.isIcann = true})
       : isException = rule.startsWith('!'),
-        labels = rule.startsWith('!') ? rule.substring(1) : rule;
+        labels = rule.startsWith('!') ? rule.substring(1) : rule {
+    _wildcards = '*'.allMatches(labels).map((m) => m.start).toList();
+  }
+
+  bool matches(String host) {
+    var hostParts = host.split('.')..removeWhere((e) => e.isEmpty);
+    var ruleParts = labels.split('.');
+
+    if (ruleParts.length <= hostParts.length) {
+      hostParts = hostParts.sublist(hostParts.length - ruleParts.length);
+
+      if (_wildcards.isNotEmpty) {
+        for (var index in _wildcards) {
+          hostParts[index] = '*';
+        }
+      }
+    }
+
+    return labels == hostParts.join('.');
+  }
 
   @override
   String toString() {

--- a/lib/src/suffix_rules.dart
+++ b/lib/src/suffix_rules.dart
@@ -14,14 +14,23 @@
 /// can be disposed of using [dispose] if it is no longer needed.
 class SuffixRules {
   static List<Rule> _rules;
+  static Map<String, Iterable<Rule>> _ruleMap;
 
   SuffixRules._();
 
-  /// Returns an unmodifiable list containing the current rules.
+  /// Returns an unmodifiable list containing the current rules in the original order.
   ///
   /// [null] is returned if the list has not been initialised.
   static List<Rule> get rules =>
       _rules != null ? List.unmodifiable(_rules) : null;
+
+  /// Returns an unmodifiable map containing the current rules.
+  ///
+  /// In each pair in the list the key is a label and the value a list of all
+  /// rules that end with that label.
+  /// [null] is returned if the map has not been initialised.
+  static Map<String, Iterable<Rule>> get ruleMap =>
+      _ruleMap != null ? Map.unmodifiable(_ruleMap) : null;
 
   /// Checks if the rule list has been initialised.
   static bool hasInitialised() => _rules != null;
@@ -43,6 +52,7 @@ class SuffixRules {
     var processed = process(rules);
     validate(processed);
     _rules = processed;
+    _ruleMap = _listToMap(_rules);
   }
 
   /// Converts a list of strings into a list of rules.
@@ -122,6 +132,21 @@ class SuffixRules {
   static bool _isValidRule(String line) =>
       RegExp(r'^(?:\*|[^*.!\s][^*.!\s]*)(?:\.(?:[*]|[^*.\s]+))*$')
           .hasMatch(line);
+
+  static Map<String, Iterable<Rule>> _listToMap(List<Rule> rules) {
+    var map = <String, List<Rule>>{};
+    for (var rule in rules) {
+      var lastLabel = rule.labels.substring(rule.labels.lastIndexOf('.') + 1);
+      if (map.containsKey(lastLabel)) {
+        map[lastLabel].add(rule);
+      } else {
+        var list = <Rule>[rule];
+        map[lastLabel] = list;
+      }
+    }
+
+    return map;
+  }
 
   /// Disposes of the suffix list.
   ///

--- a/lib/src/suffix_rules.dart
+++ b/lib/src/suffix_rules.dart
@@ -153,6 +153,7 @@ class SuffixRules {
   /// [hasInitialised] will return [false] after this has been called.
   static void dispose() {
     _rules = null;
+    _ruleMap = null;
   }
 }
 

--- a/lib/src/suffix_rules.dart
+++ b/lib/src/suffix_rules.dart
@@ -210,4 +210,28 @@ class Rule {
       return true;
     }
   }
+
+  int _compareTo(Rule other) {
+    var itr = RuneIterator.at(labels, labels.length);
+    var itr2 = RuneIterator.at(other.labels, other.labels.length);
+    var diff = 0;
+
+    while (itr.movePrevious() && itr2.movePrevious()) {
+      diff = itr.current - itr2.current;
+
+      if (diff != 0) {
+        return diff;
+      }
+    }
+
+    return 0;
+  }
+
+  bool operator <=(Rule other) => _compareTo(other) <= 0;
+
+  bool operator <(Rule other) => _compareTo(other) < 0;
+
+  bool operator >=(Rule other) => _compareTo(other) >= 0;
+
+  bool operator >(Rule other) => _compareTo(other) > 0;
 }

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -12,18 +12,18 @@ import 'package:public_suffix/public_suffix.dart';
 class DomainUtils {
   DomainUtils._();
 
-  /// Checks if a URI is a subdomain of another.
+  /// Checks if a URL is a subdomain of another.
   ///
-  /// Both URIs are parsed to [PublicSuffix] objects, which are then compared
+  /// Both URLs are parsed to [PublicSuffix] objects, which are then compared
   /// using [PublicSuffix.isSubdomainOf()].
   static bool isSubdomainOf(Uri potentialSub, Uri root, {bool icann = false}) {
-    var parsedUri = PublicSuffix(potentialSub);
+    var parsedUrl = PublicSuffix(potentialSub);
     var parsedRoot = PublicSuffix(root);
 
-    return parsedUri.isSubdomainOf(parsedRoot, icann: icann);
+    return parsedUrl.isSubdomainOf(parsedRoot, icann: icann);
   }
 
-  /// Checks if a URI is a subdomain or a root domain.
+  /// Checks if a URL is a subdomain or a root domain.
   ///
   /// [potentialSub] is parsed to a [PublicSuffix] object. It is a subdomain if
   /// the [subdomain] property of the object is [null].

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 Jakob Hjelm (Komposten)
+ *
+ * This file is part of public_suffix.
+ *
+ * public_suffix is a free Dart library: you can use, redistribute it and/or modify
+ * it under the terms of the MIT license as written in the LICENSE file in the root
+ * of this project.
+ */
+import 'package:public_suffix/public_suffix.dart';
+
+class DomainUtils {
+  DomainUtils._();
+
+  /// Checks if a URI is a subdomain of another.
+  ///
+  /// Both URIs are parsed to [PublicSuffix] objects, whose domain and subdomain
+  /// properties are then compared to determine if [potentialSub] is a subdomain
+  /// of [root]. If [icann] is [true], comparison will be based on only the
+  /// ICANN/IANA rules.
+  ///
+  /// For example, `http://images.google.co.uk` is a subdomain of `http://google.co.uk`.
+  ///
+  /// If [root] has a subdomain and [potentialSub] is a subdomain of that, [true]
+  /// is still returned.
+  static bool isSubdomainOf(Uri potentialSub, Uri root, {bool icann = false}) {
+    var parsedUri = PublicSuffix(potentialSub);
+    var parsedRoot = PublicSuffix(root);
+
+    if (icann) {
+      return parsedUri.icannDomain == parsedRoot.icannDomain &&
+          parsedUri.icannSubdomain != null &&
+          (parsedRoot.icannSubdomain == null ||
+              parsedUri.icannSubdomain.endsWith(parsedRoot.icannSubdomain));
+    } else {
+      return parsedUri.domain == parsedRoot.domain &&
+          parsedUri.subdomain != null &&
+          (parsedRoot.subdomain == null ||
+              parsedUri.subdomain.endsWith(parsedRoot.subdomain));
+    }
+  }
+}

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -36,4 +36,23 @@ class DomainUtils {
       return PublicSuffix(potentialSub).subdomain != null;
     }
   }
+
+  /// Checks if [suffix] is a known url suffix.
+  ///
+  /// For example, `co.uk` is known but `example` is not.
+  static bool isKnownSuffix(String suffix) {
+    var split = suffix.split('.');
+    var rules = SuffixRules.ruleMap[split.last] ?? <String>[];
+    var isKnown = false;
+
+    for (var rule in rules) {
+      if (rule.labels.split('.').length == split.length &&
+          rule.matches(suffix)) {
+        isKnown = true;
+        break;
+      }
+    }
+
+    return isKnown;
+  }
 }

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -55,4 +55,15 @@ class DomainUtils {
 
     return isKnown;
   }
+
+  /// Checks if the URL contains a registrable domain part.
+  ///
+  /// If [icann] is [true] the check will be based on only the ICANN/IANA rules.
+  /// If [acceptDefaultRule] is [false] URLs with suffixes only matching the
+  /// default rule (`*`) will be seen as invalid.
+  static bool hasValidDomain(Uri domain,
+      {bool icann = false, bool acceptDefaultRule = true}) {
+    return PublicSuffix(domain)
+        .hasValidDomain(icann: icann, acceptDefaultRule: acceptDefaultRule);
+  }
 }

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -14,30 +14,13 @@ class DomainUtils {
 
   /// Checks if a URI is a subdomain of another.
   ///
-  /// Both URIs are parsed to [PublicSuffix] objects, whose domain and subdomain
-  /// properties are then compared to determine if [potentialSub] is a subdomain
-  /// of [root]. If [icann] is [true], comparison will be based on only the
-  /// ICANN/IANA rules.
-  ///
-  /// For example, `http://images.google.co.uk` is a subdomain of `http://google.co.uk`.
-  ///
-  /// If [root] has a subdomain and [potentialSub] is a subdomain of that, [true]
-  /// is still returned.
+  /// Both URIs are parsed to [PublicSuffix] objects, which are then compared
+  /// using [PublicSuffix.isSubdomainOf()].
   static bool isSubdomainOf(Uri potentialSub, Uri root, {bool icann = false}) {
     var parsedUri = PublicSuffix(potentialSub);
     var parsedRoot = PublicSuffix(root);
 
-    if (icann) {
-      return parsedUri.icannDomain == parsedRoot.icannDomain &&
-          parsedUri.icannSubdomain != null &&
-          (parsedRoot.icannSubdomain == null ||
-              parsedUri.icannSubdomain.endsWith(parsedRoot.icannSubdomain));
-    } else {
-      return parsedUri.domain == parsedRoot.domain &&
-          parsedUri.subdomain != null &&
-          (parsedRoot.subdomain == null ||
-              parsedUri.subdomain.endsWith(parsedRoot.subdomain));
-    }
+    return parsedUri.isSubdomainOf(parsedRoot, icann: icann);
   }
 
   /// Checks if a URI is a subdomain or a root domain.

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -39,4 +39,18 @@ class DomainUtils {
               parsedUri.subdomain.endsWith(parsedRoot.subdomain));
     }
   }
+
+  /// Checks if a URI is a subdomain or a root domain.
+  ///
+  /// [potentialSub] is parsed to a [PublicSuffix] object. It is a subdomain if
+  /// the [subdomain] property of the object is [null].
+  ///
+  /// If [icann] is [true], [icannSubdomain] is checked instead.
+  static bool isSubdomain(Uri potentialSub, {bool icann = false}) {
+    if (icann) {
+      return PublicSuffix(potentialSub).icannSubdomain != null;
+    } else {
+      return PublicSuffix(potentialSub).subdomain != null;
+    }
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: public_suffix
 description: A domain parser based on the Public Suffix List, for identifying the root and suffix/TLD of URLs.
-version: 1.1.0
+version: 1.2.0-dev
 homepage: https://www.github.com/komposten/
 repository: https://www.github.com/komposten/public_suffix
 issue_tracker: https://www.github.com/komposten/public_suffix/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: public_suffix
 description: A domain parser based on the Public Suffix List, for identifying the root and suffix/TLD of URLs.
-version: 1.2.0-dev
+version: 1.2.0
 homepage: https://www.github.com/komposten/
 repository: https://www.github.com/komposten/public_suffix
 issue_tracker: https://www.github.com/komposten/public_suffix/issues

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -163,23 +163,29 @@ void main() {
     });
 
     test('githubIoUrl_differentOverallAndIcannData', () {
-      var suffix = PublicSuffix(Uri.parse('http://komposten.github.io'));
+      var suffix = PublicSuffix(Uri.parse('http://sub.komposten.github.io'));
       expect(suffix.root, equals('komposten'));
       expect(suffix.suffix, equals('github.io'));
+      expect(suffix.subdomain, equals('sub'));
       expect(suffix.icannRoot, equals('github'));
       expect(suffix.icannSuffix, equals('io'));
+      expect(suffix.icannSubdomain, equals('sub.komposten'));
       expect(suffix.punyDecoded.root, equals('komposten'));
       expect(suffix.punyDecoded.suffix, equals('github.io'));
+      expect(suffix.punyDecoded.subdomain, equals('sub'));
       expect(suffix.punyDecoded.icannRoot, equals('github'));
       expect(suffix.punyDecoded.icannSuffix, equals('io'));
+      expect(suffix.punyDecoded.icannSubdomain, equals('sub.komposten'));
     });
 
     test('punycodedUrl_punydecodedInstanceHasDecodedData', () {
-      var suffix = PublicSuffix(Uri.parse('http://xn--85x722f.xn--55qx5d.cn'));
-      expect(suffix.root, equals('xn--85x722f'));
+      var suffix = PublicSuffix(Uri.parse('http://xn--6qq79v.xn--85x722f.xn--55qx5d.cn'));
       expect(suffix.suffix, equals('xn--55qx5d.cn'));
-      expect(suffix.punyDecoded.root, equals('食狮'));
+      expect(suffix.root, equals('xn--85x722f'));
+      expect(suffix.subdomain, equals('xn--6qq79v'));
       expect(suffix.punyDecoded.suffix, equals('公司.cn'));
+      expect(suffix.punyDecoded.root, equals('食狮'));
+      expect(suffix.punyDecoded.subdomain, equals('你好'));
     });
 
     test('notPunycodedUrl_punydecodedInstanceHasSameData', () {

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -43,7 +43,8 @@ void main() {
       expect(suffix.domain, equals("${suffix.root}.${suffix.suffix}"));
     });
 
-    test('urlWithoutRegistrableDomain_registrableDomainAndSubdomainAreNull', () {
+    test('urlWithoutRegistrableDomain_registrableDomainAndSubdomainAreNull',
+        () {
       var suffix = PublicSuffix(Uri.parse('http://dev'));
 
       expect(suffix.root, isEmpty);
@@ -185,7 +186,8 @@ void main() {
     });
 
     test('punycodedUrl_punydecodedInstanceHasDecodedData', () {
-      var suffix = PublicSuffix(Uri.parse('http://xn--6qq79v.xn--85x722f.xn--55qx5d.cn'));
+      var suffix = PublicSuffix(
+          Uri.parse('http://xn--6qq79v.xn--85x722f.xn--55qx5d.cn'));
       expect(suffix.suffix, equals('xn--55qx5d.cn'));
       expect(suffix.root, equals('xn--85x722f'));
       expect(suffix.subdomain, equals('xn--6qq79v'));

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -7,11 +7,14 @@ void main() {
   test('PublicSuffix_PublicSuffixListNotInitialised_throwStateError', () {
     expect(
         () => PublicSuffix(Uri.parse('http://www.pub.dev')), throwsStateError);
+    expect(
+        () => PublicSuffix.fromString('http://www.pub.dev'), throwsStateError);
   });
 
   test('PublicSuffix_uriWithoutAuthority_throwArgumentError', () async {
     SuffixRules.initFromString("");
     expect(() => PublicSuffix(Uri.parse('www.pub.dev')), throwsArgumentError);
+    expect(() => PublicSuffix.fromString('www.pub.dev'), throwsArgumentError);
   });
 
   group('PublicSuffix_', () {
@@ -205,6 +208,22 @@ void main() {
     });
 
     tearDownAll(() => SuffixRules.dispose());
+  });
+
+  group('PublicSuffixFromString_', () {
+    setUpAll(() async {
+      await SuffixRulesHelper.initFromUri(getSuffixListFileUri());
+    });
+
+    test('normalUrls_parseCorrectly', () {
+      var suffix = PublicSuffix.fromString('http://www.pub.dev');
+      expect(suffix.suffix, equals('dev'));
+      expect(suffix.root, equals('pub'));
+
+      suffix = PublicSuffix.fromString('http://www.komposten.github.io');
+      expect(suffix.suffix, equals('github.io'));
+      expect(suffix.root, equals('komposten'));
+    });
   });
 
   group('isPrivateSuffix_', () {

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -224,4 +224,70 @@ void main() {
 
     tearDownAll(() => SuffixRules.dispose());
   });
+
+  group('isSubdomainOf_', () {
+    setUpAll(() async {
+      await SuffixRulesHelper.initFromUri(getSuffixListFileUri());
+    });
+
+    test('subdomainOfRoot_true', () {
+      expect(
+          PublicSuffix(Uri.parse('http://images.google.co.uk'))
+              .isSubdomainOf(PublicSuffix(Uri.parse('http://google.co.uk'))),
+          isTrue);
+    });
+
+    test('subdomainOfSubdomain_true', () {
+      expect(
+          PublicSuffix(Uri.parse('http://deeper.images.google.co.uk'))
+              .isSubdomainOf(
+                  PublicSuffix(Uri.parse('http://images.google.co.uk'))),
+          isTrue);
+    });
+
+    test('differentSubdomains_false', () {
+      expect(
+          PublicSuffix(Uri.parse('http://images.google.co.uk')).isSubdomainOf(
+              PublicSuffix(Uri.parse('http://photos.google.co.uk'))),
+          isFalse);
+      expect(
+          PublicSuffix(Uri.parse('http://deeper.images.google.co.uk'))
+              .isSubdomainOf(PublicSuffix(
+                  Uri.parse('http://deeper.images.photos.google.co.uk'))),
+          isFalse);
+    });
+
+    test('noSubdomain_false', () {
+      expect(
+          PublicSuffix(Uri.parse('http://google.co.uk'))
+              .isSubdomainOf(PublicSuffix(Uri.parse('http://google.co.uk'))),
+          isFalse);
+    });
+
+    test('differentDomains_false', () {
+      expect(
+          PublicSuffix(Uri.parse('http://images.google.co.uk'))
+              .isSubdomainOf(PublicSuffix(Uri.parse('http://google.com'))),
+          isFalse);
+      expect(
+          PublicSuffix(Uri.parse('http://images.google.co.uk'))
+              .isSubdomainOf(PublicSuffix(Uri.parse('http://googol.co.uk'))),
+          isFalse);
+    });
+
+    test('icann', () {
+      expect(
+          PublicSuffix(Uri.parse('http://komposten.github.io')).isSubdomainOf(
+              PublicSuffix(Uri.parse('http://github.io')),
+              icann: false),
+          isFalse);
+      expect(
+          PublicSuffix(Uri.parse('http://komposten.github.io')).isSubdomainOf(
+              PublicSuffix(Uri.parse('http://github.io')),
+              icann: true),
+          isTrue);
+    });
+
+    tearDownAll(() => SuffixRules.dispose());
+  });
 }

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -321,4 +321,45 @@ void main() {
 
     tearDownAll(() => SuffixRules.dispose());
   });
+
+  group('hasValidDomain_', () {
+    setUpAll(() async {
+      await SuffixRulesHelper.initFromUri(getSuffixListFileUri());
+    });
+
+    test('validDomains_true', () {
+      expect(PublicSuffix(Uri.parse('http://google.co.uk')).hasValidDomain(),
+          isTrue);
+      expect(
+          PublicSuffix(Uri.parse('http://komposten.github.io'))
+              .hasValidDomain(),
+          isTrue);
+    });
+
+    test('invalidDomains_false', () {
+      expect(PublicSuffix(Uri.parse('http://co.uk')).hasValidDomain(), isFalse);
+      expect(PublicSuffix(Uri.parse('http://github.io')).hasValidDomain(),
+          isFalse);
+    });
+
+    test('icann', () {
+      expect(PublicSuffix(Uri.parse('http://github.io')).hasValidDomain(),
+          isFalse);
+      expect(
+          PublicSuffix(Uri.parse('http://github.io'))
+              .hasValidDomain(icann: true),
+          isTrue);
+    });
+
+    test('dontAcceptDefaultRule', () {
+      expect(PublicSuffix(Uri.parse('http://example.example')).hasValidDomain(),
+          isTrue);
+      expect(
+          PublicSuffix(Uri.parse('http://example.example'))
+              .hasValidDomain(acceptDefaultRule: false),
+          isFalse);
+    });
+
+    tearDownAll(() => SuffixRules.dispose());
+  });
 }

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -43,12 +43,18 @@ void main() {
       expect(suffix.domain, equals("${suffix.root}.${suffix.suffix}"));
     });
 
-    test('urlWithoutRegistrableDomain_registrableDomainIsNull', () {
+    test('urlWithoutRegistrableDomain_registrableDomainAndSubdomainAreNull', () {
       var suffix = PublicSuffix(Uri.parse('http://dev'));
 
       expect(suffix.root, isEmpty);
       expect(suffix.suffix, equals('dev'));
       expect(suffix.domain, isNull);
+      expect(suffix.subdomain, isNull);
+    });
+
+    test('urlWithoutSubdomain_subdomainIsNull', () {
+      var suffix = PublicSuffix(Uri.parse('http://pub.dev'));
+      expect(suffix.subdomain, isNull);
     });
 
     test('basicUrls_correctlyIdentifyRootAndTld', () {

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -290,4 +290,35 @@ void main() {
 
     tearDownAll(() => SuffixRules.dispose());
   });
+
+  group('hasKnownSuffix_', () {
+    setUpAll(() async {
+      await SuffixRulesHelper.initFromUri(getSuffixListFileUri());
+    });
+
+    test('knownSuffixes_true', () {
+      // Exact matches
+      expect(PublicSuffix(Uri.parse('http://google.co.uk')).hasKnownSuffix(),
+          isTrue);
+      expect(
+          PublicSuffix(Uri.parse('http://komposten.github.io'))
+              .hasKnownSuffix(),
+          isTrue);
+      // Wildcard matches
+      expect(
+          PublicSuffix(Uri.parse('http://mouse.cat.moonscale.io'))
+              .hasKnownSuffix(),
+          isTrue);
+    });
+
+    test('unknownSuffixes_false', () {
+      expect(PublicSuffix(Uri.parse('http://example.example')).hasKnownSuffix(),
+          isFalse);
+      expect(
+          PublicSuffix(Uri.parse('http://komposten.hamster')).hasKnownSuffix(),
+          isFalse);
+    });
+
+    tearDownAll(() => SuffixRules.dispose());
+  });
 }

--- a/test/public_suffix_browser_test.dart
+++ b/test/public_suffix_browser_test.dart
@@ -6,8 +6,8 @@ void main() {
   tearDown(() => SuffixRules.dispose());
 
   test('initPublicSuffixList_crossDomainUrl_initList', () async {
-    await SuffixRulesHelper.initFromUri(
-        Uri.parse('https://publicsuffix.org/list/public_suffix_list.dat'));
+    await SuffixRulesHelper.initFromUri(Uri.parse(
+        'https://raw.githubusercontent.com/Komposten/public_suffix/master/test/res/public_suffix_list.dat'));
     expect(SuffixRules.hasInitialised(), isTrue);
     expect(SuffixRules.rules, isNotEmpty);
   });

--- a/test/public_suffix_browser_test.dart
+++ b/test/public_suffix_browser_test.dart
@@ -12,6 +12,12 @@ void main() {
     expect(SuffixRules.rules, isNotEmpty);
   });
 
+  test('initPublicSuffixList_resourceDoesNotExist_fail', () async {
+    var uri = Uri.parse(
+        "https://raw.githubusercontent.com/Komposten/public_suffix/master/test/res/i_dont_exist.dat");
+    expect(SuffixRulesHelper.initFromUri(uri), throwsException);
+  });
+
   test('initPublicSuffixList_fileAccessDenied_fail', () async {
     var file = Uri.file("/public_suffix_list.dat");
 

--- a/test/public_suffix_io_test.dart
+++ b/test/public_suffix_io_test.dart
@@ -13,6 +13,12 @@ void main() {
     expect(SuffixRules.rules, isNotEmpty);
   });
 
+  test('initPublicSuffixList_resourceDoesNotExist_fail', () async {
+    var uri = Uri.parse(
+        "https://raw.githubusercontent.com/Komposten/public_suffix/master/test/res/i_dont_exist.dat");
+    expect(SuffixRulesHelper.initFromUri(uri), throwsException);
+  });
+
   test('initPublicSuffixList_invalidUrl_throwException', () async {
     expect(
         SuffixRulesHelper.initFromUri(Uri.parse('http://127.0.0.2/list.dat')),

--- a/test/public_suffix_io_test.dart
+++ b/test/public_suffix_io_test.dart
@@ -7,8 +7,8 @@ void main() {
   tearDown(() => SuffixRules.dispose());
 
   test('initPublicSuffixList_crossDomainUrl_initList', () async {
-    await SuffixRulesHelper.initFromUri(
-        Uri.parse('https://publicsuffix.org/list/public_suffix_list.dat'));
+    await SuffixRulesHelper.initFromUri(Uri.parse(
+        'https://raw.githubusercontent.com/Komposten/public_suffix/master/test/res/public_suffix_list.dat'));
     expect(SuffixRules.hasInitialised(), isTrue);
     expect(SuffixRules.rules, isNotEmpty);
   });

--- a/test/suffix_rules_test.dart
+++ b/test/suffix_rules_test.dart
@@ -177,6 +177,36 @@ void main() {
     });
   });
 
+  group('ruleMap_', () {
+    tearDown(() => SuffixRules.dispose());
+
+    test('afterInitialising_returnMap', () {
+      SuffixRules.initFromList(['br', 'br.nom']);
+      expect(SuffixRules.ruleMap, isNotNull);
+      expect(SuffixRules.ruleMap, hasLength(2));
+      expect(SuffixRules.ruleMap, containsPair('br', [Rule('br')]));
+    });
+
+    test('beforeInitialising_returnNull', () {
+      expect(SuffixRules.ruleMap, isNull);
+    });
+
+    test('multipleRulesFromSameTld_combineIntoSameList', () {
+      SuffixRules.initFromList(['br', 'nom.br', 'nom.mer.br']);
+      expect(SuffixRules.ruleMap, isNotNull);
+      expect(SuffixRules.ruleMap, hasLength(1));
+      expect(SuffixRules.ruleMap,
+          containsPair('br', [Rule('br'), Rule('nom.br'), Rule('nom.mer.br')]));
+    });
+
+    test('modifyMap_exception', () {
+      SuffixRules.initFromList(['br', 'nom.br']);
+      expect(() => SuffixRules.ruleMap['rb'] = [Rule('rb')],
+          throwsUnsupportedError);
+      expect(() => SuffixRules.ruleMap.remove('br'), throwsUnsupportedError);
+    });
+  });
+
   group('initFromList_', () {
     test('listWithComments_commentsRemoved', () {
       var lines = <String>['br', '//comment', 'nom.br'];

--- a/test/utilities_test.dart
+++ b/test/utilities_test.dart
@@ -19,8 +19,8 @@ void main() {
       var publicSuffix1 = PublicSuffix(uri1);
       var publicSuffix2 = PublicSuffix(uri2);
 
-      expect(DomainUtils.isSubdomainOf(uri1, uri2),
-          equals(publicSuffix1.isSubdomainOf(publicSuffix2)));
+      expect(DomainUtils.isSubdomainOf(uri1, uri2, icann: icann),
+          equals(publicSuffix1.isSubdomainOf(publicSuffix2, icann: icann)));
     }
 
     test('variousSituations_sameResultAsPublicSuffixIsSubdomain', () {

--- a/test/utilities_test.dart
+++ b/test/utilities_test.dart
@@ -82,4 +82,27 @@ void main() {
       expect(DomainUtils.isKnownSuffix('hamster.io'), isFalse);
     });
   });
+
+  group('hasValidDomain_', () {
+    void testValidDomain(String domain,
+        {bool icann = false, bool defaultRule = true}) {
+      var uri = Uri.parse(domain);
+      var publicSuffix1 = PublicSuffix(uri);
+
+      expect(
+          DomainUtils.hasValidDomain(uri,
+              icann: icann, acceptDefaultRule: defaultRule),
+          equals(publicSuffix1.hasValidDomain(
+              icann: icann, acceptDefaultRule: defaultRule)));
+    }
+
+    test('variousSituations_sameResultAsPublicSuffiHasValidDomain', () {
+      testValidDomain('http://google.co.uk');
+      testValidDomain('http://komposten.github.io');
+      testValidDomain('http://co.uk');
+      testValidDomain('http://github.io');
+      testValidDomain('http://github.io', icann: true);
+      testValidDomain('http://example.example', defaultRule: false);
+    });
+  });
 }

--- a/test/utilities_test.dart
+++ b/test/utilities_test.dart
@@ -71,4 +71,31 @@ void main() {
           isTrue);
     });
   });
+
+  group('isSubdomain', () {
+    test('rootDomain_false', () {
+      expect(
+          DomainUtils.isSubdomain(Uri.parse('http://google.co.uk')), isFalse);
+    });
+
+    test('subdomains_true', () {
+      expect(DomainUtils.isSubdomain(Uri.parse('http://images.google.co.uk')),
+          isTrue);
+      expect(
+          DomainUtils.isSubdomain(
+              Uri.parse('http://deeper.images.google.co.uk')),
+          isTrue);
+    });
+
+    test('icann', () {
+      expect(
+          DomainUtils.isSubdomain(Uri.parse('http://komposten.github.io'),
+              icann: false),
+          isFalse);
+      expect(
+          DomainUtils.isSubdomain(Uri.parse('http://komposten.github.io'),
+              icann: true),
+          isTrue);
+    });
+  });
 }

--- a/test/utilities_test.dart
+++ b/test/utilities_test.dart
@@ -67,4 +67,19 @@ void main() {
           isTrue);
     });
   });
+
+  group('isKnownSuffix', () {
+    test('knownSuffixes_true', () {
+      // Exact matches
+      expect(DomainUtils.isKnownSuffix('co.uk'), isTrue);
+      expect(DomainUtils.isKnownSuffix('github.io'), isTrue);
+      // Wildcard matches
+      expect(DomainUtils.isKnownSuffix('cat.moonscale.io'), isTrue);
+    });
+
+    test('unknownSuffixes_false', () {
+      expect(DomainUtils.isKnownSuffix('example'), isFalse);
+      expect(DomainUtils.isKnownSuffix('hamster.io'), isFalse);
+    });
+  });
 }

--- a/test/utilities_test.dart
+++ b/test/utilities_test.dart
@@ -13,62 +13,31 @@ void main() {
   });
 
   group('isSubdomainOf_', () {
-    test('subdomainOfRoot_true', () {
-      expect(
-          DomainUtils.isSubdomainOf(Uri.parse('http://images.google.co.uk'),
-              Uri.parse('http://google.co.uk')),
-          isTrue);
-    });
+    void testSubdomainOf(String domain1, String domain2, {bool icann = false}) {
+      var uri1 = Uri.parse(domain1);
+      var uri2 = Uri.parse(domain2);
+      var publicSuffix1 = PublicSuffix(uri1);
+      var publicSuffix2 = PublicSuffix(uri2);
 
-    test('subdomainOfSubdomain_true', () {
-      expect(
-          DomainUtils.isSubdomainOf(
-              Uri.parse('http://deeper.images.google.co.uk'),
-              Uri.parse('http://images.google.co.uk')),
-          isTrue);
-    });
+      expect(DomainUtils.isSubdomainOf(uri1, uri2),
+          equals(publicSuffix1.isSubdomainOf(publicSuffix2)));
+    }
 
-    test('differentSubdomains_false', () {
-      expect(
-          DomainUtils.isSubdomainOf(Uri.parse('http://images.google.co.uk'),
-              Uri.parse('http://photos.google.co.uk')),
-          isFalse);
-      expect(
-          DomainUtils.isSubdomainOf(
-              Uri.parse('http://deeper.images.google.co.uk'),
-              Uri.parse('http://deeper.images.photos.google.co.uk')),
-          isFalse);
-    });
-
-    test('noSubdomain_false', () {
-      expect(
-          DomainUtils.isSubdomainOf(Uri.parse('http://google.co.uk'),
-              Uri.parse('http://google.co.uk')),
-          isFalse);
-    });
-
-    test('differentDomains_false', () {
-      expect(
-          DomainUtils.isSubdomainOf(Uri.parse('http://images.google.co.uk'),
-              Uri.parse('http://google.com')),
-          isFalse);
-      expect(
-          DomainUtils.isSubdomainOf(Uri.parse('http://images.google.co.uk'),
-              Uri.parse('http://googol.co.uk')),
-          isFalse);
-    });
-
-    test('icann', () {
-      expect(
-          DomainUtils.isSubdomainOf(Uri.parse('http://komposten.github.io'),
-              Uri.parse('http://github.io'),
-              icann: false),
-          isFalse);
-      expect(
-          DomainUtils.isSubdomainOf(Uri.parse('http://komposten.github.io'),
-              Uri.parse('http://github.io'),
-              icann: true),
-          isTrue);
+    test('variousSituations_sameResultAsPublicSuffixIsSubdomain', () {
+      testSubdomainOf('http://images.google.co.uk', 'http://google.co.uk');
+      testSubdomainOf(
+          'http://deeper.images.google.co.uk', 'http://images.google.co.uk');
+      testSubdomainOf(
+          'http://images.google.co.uk', 'http://photos.google.co.uk');
+      testSubdomainOf('http://deeper.images.google.co.uk',
+          'http://deeper.images.photos.google.co.uk');
+      testSubdomainOf('http://google.co.uk', 'http://google.co.uk');
+      testSubdomainOf('http://images.google.co.uk', 'http://google.com');
+      testSubdomainOf('http://images.google.co.uk', 'http://googol.co.uk');
+      testSubdomainOf('http://komposten.github.io', 'http://github.io',
+          icann: false);
+      testSubdomainOf('http://komposten.github.io', 'http://github.io',
+          icann: true);
     });
   });
 

--- a/test/utilities_test.dart
+++ b/test/utilities_test.dart
@@ -1,0 +1,74 @@
+@TestOn('vm')
+import 'package:public_suffix/public_suffix_io.dart';
+import 'package:test/test.dart';
+import 'io_test_utils.dart';
+
+void main() {
+  setUpAll(() async {
+    await SuffixRulesHelper.initFromUri(getSuffixListFileUri());
+  });
+
+  tearDownAll(() {
+    SuffixRules.dispose();
+  });
+
+  group('isSubdomainOf_', () {
+    test('subdomainOfRoot_true', () {
+      expect(
+          DomainUtils.isSubdomainOf(Uri.parse('http://images.google.co.uk'),
+              Uri.parse('http://google.co.uk')),
+          isTrue);
+    });
+
+    test('subdomainOfSubdomain_true', () {
+      expect(
+          DomainUtils.isSubdomainOf(
+              Uri.parse('http://deeper.images.google.co.uk'),
+              Uri.parse('http://images.google.co.uk')),
+          isTrue);
+    });
+
+    test('differentSubdomains_false', () {
+      expect(
+          DomainUtils.isSubdomainOf(Uri.parse('http://images.google.co.uk'),
+              Uri.parse('http://photos.google.co.uk')),
+          isFalse);
+      expect(
+          DomainUtils.isSubdomainOf(
+              Uri.parse('http://deeper.images.google.co.uk'),
+              Uri.parse('http://deeper.images.photos.google.co.uk')),
+          isFalse);
+    });
+
+    test('noSubdomain_false', () {
+      expect(
+          DomainUtils.isSubdomainOf(Uri.parse('http://google.co.uk'),
+              Uri.parse('http://google.co.uk')),
+          isFalse);
+    });
+
+    test('differentDomains_false', () {
+      expect(
+          DomainUtils.isSubdomainOf(Uri.parse('http://images.google.co.uk'),
+              Uri.parse('http://google.com')),
+          isFalse);
+      expect(
+          DomainUtils.isSubdomainOf(Uri.parse('http://images.google.co.uk'),
+              Uri.parse('http://googol.co.uk')),
+          isFalse);
+    });
+
+    test('icann', () {
+      expect(
+          DomainUtils.isSubdomainOf(Uri.parse('http://komposten.github.io'),
+              Uri.parse('http://github.io'),
+              icann: false),
+          isFalse);
+      expect(
+          DomainUtils.isSubdomainOf(Uri.parse('http://komposten.github.io'),
+              Uri.parse('http://github.io'),
+              icann: true),
+          isTrue);
+    });
+  });
+}


### PR DESCRIPTION
**Additions**
- Added a hash map-based `ruleMap` to `SuffixRules` to speed up the performance when matching rules.
- Added `subdomain` and `icannSubdomain` to `PublicSuffix`.
- Added `isSubdomainOf`, `hasKnownSuffix` and `hasValidDomain` to `PublicSuffix`.
- Added `DomainUtils` with the following static functions:
    - `isSubdomainOf`
    - `isSubdomain`
    - `isKnownSuffix`
    - `hasValidDomain`
- Added `PublicSuffix.fromString` as a convenience method for `PublicSuffix(Uri.parse(string))`.

**Changes**
- Updated docs and parameter names to say URL instead of URI, which is more correct (`PublicSuffix.sourceUri` is unchanged to avoid breaking changes).