### PR TITLE
Migrated to nndb.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
     - /^(?i:release)-.+$/
 dart:
   - stable
-  - "2.2.0"
+  - "2.12.0"
 dart_task:
   - test: --platform vm
   - test: --platform chrome

--- a/example/instance_list.dart
+++ b/example/instance_list.dart
@@ -11,8 +11,8 @@ Future<void> main() async {
 
   // Parse a URL.
   // Specify a rule list to use that instead of DefaultSuffixRules.
-  var parsedUrl = PublicSuffix.fromString('https://www.komposten.github.io',
-      suffixRules: suffixRules)!;
+  var parsedUrl = PublicSuffix(urlString: 'https://www.komposten.github.io',
+      suffixRules: suffixRules);
 
   // Results when matching against both ICANN/IANA and private suffixes.
   print(parsedUrl.suffix); // github.io
@@ -25,7 +25,8 @@ Future<void> main() async {
   print(parsedUrl.icannDomain); // github.io
 
   // Punycode decoded results.
-  parsedUrl = PublicSuffix.fromString('https://www.xn--6qq79v.cn')!;
+  parsedUrl = PublicSuffix(urlString: 'https://www.xn--6qq79v.cn',
+      suffixRules: suffixRules);
   print(parsedUrl.domain); // xn--6qq79v.cn
-  print(parsedUrl.punyDecoded!.domain); // 你好.cn
+  print(parsedUrl.punyDecoded.domain); // 你好.cn
 }

--- a/example/instance_list.dart
+++ b/example/instance_list.dart
@@ -12,7 +12,7 @@ Future<void> main() async {
   // Parse a URL.
   // Specify a rule list to use that instead of DefaultSuffixRules.
   var parsedUrl = PublicSuffix.fromString('https://www.komposten.github.io',
-      suffixRules: suffixRules);
+      suffixRules: suffixRules)!;
 
   // Results when matching against both ICANN/IANA and private suffixes.
   print(parsedUrl.suffix); // github.io
@@ -25,7 +25,7 @@ Future<void> main() async {
   print(parsedUrl.icannDomain); // github.io
 
   // Punycode decoded results.
-  parsedUrl = PublicSuffix.fromString('https://www.xn--6qq79v.cn');
+  parsedUrl = PublicSuffix.fromString('https://www.xn--6qq79v.cn')!;
   print(parsedUrl.domain); // xn--6qq79v.cn
-  print(parsedUrl.punyDecoded.domain); // 你好.cn
+  print(parsedUrl.punyDecoded!.domain); // 你好.cn
 }

--- a/example/static_list.dart
+++ b/example/static_list.dart
@@ -11,7 +11,7 @@ Future<void> main() async {
 
   // Parse a URL.
   // If we don't specify a rule list, PublicSuffix uses DefaultSuffixRules.
-  var parsedUrl = PublicSuffix.fromString('https://www.komposten.github.io')!;
+  var parsedUrl = PublicSuffix(urlString: 'https://www.komposten.github.io');
 
   // Results when matching against both ICANN/IANA and private suffixes.
   print(parsedUrl.suffix); // github.io
@@ -24,9 +24,9 @@ Future<void> main() async {
   print(parsedUrl.icannDomain); // github.io
 
   // Punycode decoded results.
-  parsedUrl = PublicSuffix.fromString('https://www.xn--6qq79v.cn')!;
+  parsedUrl = PublicSuffix(urlString: 'https://www.xn--6qq79v.cn');
   print(parsedUrl.domain); // xn--6qq79v.cn
-  print(parsedUrl.punyDecoded!.domain); // 你好.cn
+  print(parsedUrl.punyDecoded.domain); // 你好.cn
 
   // Dispose the list to unload it from memory if you wish.
   // This is probably not needed since the list is relatively small.

--- a/example/static_list.dart
+++ b/example/static_list.dart
@@ -11,7 +11,7 @@ Future<void> main() async {
 
   // Parse a URL.
   // If we don't specify a rule list, PublicSuffix uses DefaultSuffixRules.
-  var parsedUrl = PublicSuffix.fromString('https://www.komposten.github.io');
+  var parsedUrl = PublicSuffix.fromString('https://www.komposten.github.io')!;
 
   // Results when matching against both ICANN/IANA and private suffixes.
   print(parsedUrl.suffix); // github.io
@@ -24,9 +24,9 @@ Future<void> main() async {
   print(parsedUrl.icannDomain); // github.io
 
   // Punycode decoded results.
-  parsedUrl = PublicSuffix.fromString('https://www.xn--6qq79v.cn');
+  parsedUrl = PublicSuffix.fromString('https://www.xn--6qq79v.cn')!;
   print(parsedUrl.domain); // xn--6qq79v.cn
-  print(parsedUrl.punyDecoded.domain); // 你好.cn
+  print(parsedUrl.punyDecoded!.domain); // 你好.cn
 
   // Dispose the list to unload it from memory if you wish.
   // This is probably not needed since the list is relatively small.

--- a/lib/src/browser/suffix_rules_helper.dart
+++ b/lib/src/browser/suffix_rules_helper.dart
@@ -29,10 +29,10 @@ class SuffixRulesHelper {
   ///
   /// An [Exception] is thrown if the request fails.
   static Future<void> initDefaultListFromUri(Uri uri,
-      {bool withCredentials,
-      Map<String, String> requestHeaders,
+      {bool? withCredentials,
+      Map<String, String>? requestHeaders,
       dynamic sendData,
-      void Function(ProgressEvent) onProgress}) async {
+      void Function(ProgressEvent)? onProgress}) async {
     DefaultSuffixRules.initFromString(await _getUri(uri,
         withCredentials: withCredentials,
         requestHeaders: requestHeaders,
@@ -51,10 +51,10 @@ class SuffixRulesHelper {
   ///
   /// An [Exception] is thrown if the request fails.
   static Future<SuffixRules> createListFromUri(Uri uri,
-      {bool withCredentials,
-      Map<String, String> requestHeaders,
+      {bool? withCredentials,
+      Map<String, String>? requestHeaders,
       dynamic sendData,
-      void Function(ProgressEvent) onProgress}) async {
+      void Function(ProgressEvent)? onProgress}) async {
     return SuffixRules.fromString(await _getUri(uri,
         withCredentials: withCredentials,
         requestHeaders: requestHeaders,
@@ -62,11 +62,11 @@ class SuffixRulesHelper {
         onProgress: onProgress));
   }
 
-  static Future<String> _getUri(Uri uri,
-      {bool withCredentials,
-      Map<String, String> requestHeaders,
+  static Future<String?> _getUri(Uri uri,
+      {bool? withCredentials,
+      Map<String, String>? requestHeaders,
       dynamic sendData,
-      void Function(ProgressEvent) onProgress}) async {
+      void Function(ProgressEvent)? onProgress}) async {
     try {
       var request = await HttpRequest.request(uri.toString(),
           withCredentials: withCredentials,
@@ -77,7 +77,6 @@ class SuffixRulesHelper {
       switch (request.status) {
         case 200:
           return request.responseText;
-          break;
         default:
           throw request;
       }
@@ -85,7 +84,7 @@ class SuffixRulesHelper {
       var object = e;
 
       if (e is ProgressEvent) {
-        object = e.target;
+        throw Exception('Request for public suffix list failed: ${e.target}');
       }
 
       if (object is HttpRequest) {

--- a/lib/src/default_suffix_rules.dart
+++ b/lib/src/default_suffix_rules.dart
@@ -15,16 +15,16 @@ import 'package:public_suffix/public_suffix.dart';
 ///
 /// After initialisation the rules can be accessed using [rules].
 class DefaultSuffixRules {
-  static SuffixRules _rules;
+  static SuffixRules? _rules;
 
   /// Returns the default suffix rules.
   ///
   /// [null] is returned if the list has not been initialised.
-  static SuffixRules get rules => _rules;
+  static SuffixRules? get rules => _rules;
 
   /// Returns the default suffix rules or throws if they haven't
   /// been initialised.
-  static SuffixRules rulesOrThrow() {
+  static SuffixRules? rulesOrThrow() {
     if (hasInitialised()) {
       return rules;
     } else {
@@ -40,7 +40,7 @@ class DefaultSuffixRules {
   /// Initialises the default rule list from a multi-rule string.
   ///
   /// See [SuffixRules.fromString] for details.
-  static void initFromString(String rules) {
+  static void initFromString(String? rules) {
     _rules = SuffixRules.fromString(rules);
   }
 

--- a/lib/src/default_suffix_rules.dart
+++ b/lib/src/default_suffix_rules.dart
@@ -24,9 +24,9 @@ class DefaultSuffixRules {
 
   /// Returns the default suffix rules or throws if they haven't
   /// been initialised.
-  static SuffixRules? rulesOrThrow() {
+  static SuffixRules rulesOrThrow() {
     if (hasInitialised()) {
-      return rules;
+      return rules!;
     } else {
       throw StateError('PublicSuffixList has not been initialised!');
     }

--- a/lib/src/io/suffix_rules_helper.dart
+++ b/lib/src/io/suffix_rules_helper.dart
@@ -69,7 +69,6 @@ class SuffixRulesHelper {
     switch (response.statusCode) {
       case 200:
         return await response.transform(Utf8Decoder()).join();
-        break;
       default:
         throw Exception(
             'Request for public suffix list failed: [${response.statusCode}]');

--- a/lib/src/public_suffix_base.dart
+++ b/lib/src/public_suffix_base.dart
@@ -422,7 +422,7 @@ class PublicSuffix {
     return (root.isNotEmpty ? '$root.$suffix' : null);
   }
 
-  String _getSubdomain(String host, String? registrableDomain) {
+  String? _getSubdomain(String host, String? registrableDomain) {
     var sub;
 
     if (registrableDomain != null) {

--- a/lib/src/public_suffix_base.dart
+++ b/lib/src/public_suffix_base.dart
@@ -15,77 +15,77 @@ import 'suffix_rules.dart';
 
 /// A description of the public suffix, root domain and registrable domain for a URL.
 class PublicSuffix {
-  Uri _sourceUrl;
+  Uri? _sourceUrl;
 
   bool _sourcePunycoded = false;
-  bool _hasKnownSuffix;
-  String _root;
-  String _suffix;
-  String _domain;
-  String _subdomain;
-  String _icannRoot;
-  String _icannSuffix;
-  String _icannDomain;
-  String _icannSubdomain;
+  bool? _hasKnownSuffix;
+  String? _root;
+  String? _suffix;
+  String? _domain;
+  String? _subdomain;
+  String? _icannRoot;
+  String? _icannSuffix;
+  String? _icannDomain;
+  String? _icannSubdomain;
 
-  PublicSuffix _punyDecoded;
+  PublicSuffix? _punyDecoded;
 
-  Uri get sourceUrl => _sourceUrl;
+  Uri? get sourceUrl => _sourceUrl;
 
   /// Returns the registrable domain part of the URL, based on both ICANN/IANA and private rules.
   ///
   /// The registrable domain is the public suffix and one preceding label.
   /// For example, `images.google.co.uk` has the registrable domain `google.co.uk`.
-  String get domain => _domain;
+  String? get domain => _domain;
 
   /// Returns the subdomain part of the URL, based on both ICANN/IANA and private rules.
   ///
   /// The subdomain is the part of the host that precedes the registrable domain
   /// (see [domain]).
   /// For example, `images.google.co.uk` has the subdomain `images`.
-  String get subdomain => _subdomain;
+  String? get subdomain => _subdomain;
 
   /// Returns the root domain part of the URL, based on both ICANN/IANA and private rules.
   ///
   /// The root domain is the label that precedes the public suffix.
   /// For example, `images.google.co.uk` has the root domain `google`.
-  String get root => _root;
+  String? get root => _root;
 
   /// Returns the public suffix part of the URL, based on both ICANN/IANA and private rules.
   ///
   /// The public suffix is the labels at the end of the URL which are not controlled
   /// by the registrant of the domain.
   /// For example, `images.google.co.uk` has the public suffix `co.uk`.
-  String get suffix => _suffix;
+  String? get suffix => _suffix;
 
   /// Returns the registrable domain part of the URL, based on ICANN/IANA rules.
   ///
   /// The registrable domain is the public suffix and one preceding label.
   /// For example, `images.google.co.uk` has the registrable domain `google.co.uk`.
-  String get icannDomain => _icannDomain;
+  String? get icannDomain => _icannDomain;
 
   /// Returns the subdomain part of the URL, based on ICANN/IANA rules.
   ///
   /// The subdomain is the part of the host that precedes the registrable domain
   /// (see [domain]).
   /// For example, `images.google.co.uk` has the subdomain `images`.
-  String get icannSubdomain => _icannSubdomain;
+  String? get icannSubdomain => _icannSubdomain;
 
   /// Returns the root domain part of the URL, based on ICANN/IANA rules.
   ///
   /// The root domain is the label that precedes the public suffix.
   /// For example, `images.google.co.uk` has the root domain `google`.
-  String get icannRoot => _icannRoot;
+  String? get icannRoot => _icannRoot;
 
   /// Returns the public suffix part of the URL, based on ICANN/IANA rules.
   ///
   /// The public suffix is the labels at the end of the URL which are not controlled
   /// by the registrant of the domain.
   /// For example, `images.google.co.uk` has the public suffix `co.uk`.
-  String get icannSuffix => _icannSuffix;
+  String? get icannSuffix => _icannSuffix;
 
   /// Returns a punycode decoded version of this object.
-  PublicSuffix get punyDecoded => _punyDecoded;
+  PublicSuffix? get punyDecoded => _punyDecoded;
 
   /// Checks if the URL was matched with a private rule rather than an ICANN/IANA rule.
   ///
@@ -96,7 +96,7 @@ class PublicSuffix {
   /// Whether the [suffix] is a known suffix or not.
   ///
   /// A known suffix is one which has a rule in the suffix rule list.
-  bool hasKnownSuffix() => _hasKnownSuffix;
+  bool? hasKnownSuffix() => _hasKnownSuffix;
 
   /// Checks if the registrable domain is valid.
   ///
@@ -107,7 +107,7 @@ class PublicSuffix {
   bool hasValidDomain({bool icann = false, bool acceptDefaultRule = true}) {
     var _domain = (icann ? icannDomain : domain);
 
-    if (acceptDefaultRule || hasKnownSuffix()) {
+    if (acceptDefaultRule || hasKnownSuffix()!) {
       return _domain != null;
     } else {
       return false;
@@ -129,11 +129,11 @@ class PublicSuffix {
       return icannDomain == other.icannDomain &&
           icannSubdomain != null &&
           (other.icannSubdomain == null ||
-              icannSubdomain.endsWith(other.icannSubdomain));
+              icannSubdomain!.endsWith(other.icannSubdomain!));
     } else {
       return domain == other.domain &&
           subdomain != null &&
-          (other.subdomain == null || subdomain.endsWith(other.subdomain));
+          (other.subdomain == null || subdomain!.endsWith(other.subdomain!));
     }
   }
 
@@ -158,8 +158,8 @@ class PublicSuffix {
   /// [suffixRules] can be used to specify the rules to be used when
   /// parsing the URL. If not specified, [DefaultSuffixRules.rules] will
   /// be used.
-  factory PublicSuffix.fromString(String url,
-      {SuffixRules suffixRules, Leniency leniency = Leniency.allowEmptyUrl}) {
+  static PublicSuffix? fromString(String? url,
+      {SuffixRules? suffixRules, Leniency leniency = Leniency.allowEmptyUrl}) {
     try {
       return PublicSuffix(urlString: url, suffixRules: suffixRules);
     } catch (e) {
@@ -193,8 +193,8 @@ class PublicSuffix {
   /// [suffixRules] can be used to specify the rules to be used when
   /// parsing the URL. If not specified, [DefaultSuffixRules.rules] will
   /// be used.
-  factory PublicSuffix.fromUrl(Uri url,
-      {SuffixRules suffixRules, Leniency leniency = Leniency.allowEmptyUrl}) {
+  static PublicSuffix? fromUrl(Uri? url,
+      {SuffixRules? suffixRules, Leniency leniency = Leniency.allowEmptyUrl}) {
     try {
       return PublicSuffix(url: url, suffixRules: suffixRules);
     } catch (e) {
@@ -210,8 +210,8 @@ class PublicSuffix {
 
   PublicSuffix._(this._sourceUrl, String host, this._root, this._suffix,
       this._icannRoot, this._icannSuffix) {
-    _domain = _buildRegistrableDomain(_root, _suffix);
-    _icannDomain = _buildRegistrableDomain(_icannRoot, _icannSuffix);
+    _domain = _buildRegistrableDomain(_root!, _suffix);
+    _icannDomain = _buildRegistrableDomain(_icannRoot!, _icannSuffix);
     _subdomain = _getSubdomain(host, _domain);
     _icannSubdomain = _getSubdomain(host, _icannDomain);
   }
@@ -229,26 +229,26 @@ class PublicSuffix {
   ///
   /// Throws an [ArgumentError] if [sourceUrl] is missing the authority component
   /// (e.g. if no protocol is specified).
-  PublicSuffix({Uri url, String urlString, SuffixRules suffixRules}) {
+  PublicSuffix({Uri? url, String? urlString, SuffixRules? suffixRules}) {
     if (url == null && urlString == null) {
       throw ArgumentError('Either url or urlString must be specified!');
     }
 
-    _sourceUrl = url ?? Uri.parse(urlString);
-    if (!sourceUrl.hasAuthority) {
+    _sourceUrl = url ?? Uri.parse(urlString!);
+    if (!sourceUrl!.hasAuthority) {
       throw ArgumentError(
           'The URL is missing the authority component: $sourceUrl');
     }
 
     suffixRules ??= DefaultSuffixRules.rulesOrThrow();
-    _parseUrl(sourceUrl, suffixRules.ruleMap);
+    _parseUrl(sourceUrl!, suffixRules!.ruleMap);
   }
 
   void _parseUrl(Uri url, Map<String, Iterable<Rule>> suffixMap) {
     var host = _decodeHost(url);
     var matchingRules = _findMatchingRules(host, suffixMap);
-    var prevailingIcannRule = _getPrevailingRule(matchingRules['icann']);
-    var prevailingAllRule = _getPrevailingRule(matchingRules['all']);
+    var prevailingIcannRule = _getPrevailingRule(matchingRules['icann']!);
+    var prevailingAllRule = _getPrevailingRule(matchingRules['all']!);
 
     if (prevailingIcannRule.isException) {
       prevailingIcannRule = _trimExceptionRule(prevailingIcannRule);
@@ -288,7 +288,7 @@ class PublicSuffix {
       _sourcePunycoded = true;
       var offset = 0;
       punycodes.forEach((match) {
-        var decoded = punycodeDecode(match.group(0).substring(4));
+        var decoded = punycodeDecode(match.group(0)!.substring(4));
         host = host.replaceRange(
             match.start - offset, match.end - offset, decoded);
         offset += (match.end - match.start) - decoded.length;
@@ -322,7 +322,7 @@ class PublicSuffix {
   }
 
   Rule _getPrevailingRule(List<Rule> matchingRules) {
-    Rule prevailing;
+    Rule? prevailing;
     var longestLength = 0;
 
     for (var rule in matchingRules) {
@@ -412,11 +412,11 @@ class PublicSuffix {
     }).join('.');
   }
 
-  String _buildRegistrableDomain(String root, String suffix) {
+  String? _buildRegistrableDomain(String root, String? suffix) {
     return (root.isNotEmpty ? '$root.$suffix' : null);
   }
 
-  String _getSubdomain(String host, String registrableDomain) {
+  String? _getSubdomain(String host, String? registrableDomain) {
     var sub;
 
     if (registrableDomain != null) {

--- a/lib/src/suffix_rules.dart
+++ b/lib/src/suffix_rules.dart
@@ -15,8 +15,8 @@ import 'package:public_suffix/src/suffix_rules_parser.dart';
 /// Rules are parsed from either a string or a list and can
 /// then be accessed using [rules] or [ruleMap].
 class SuffixRules {
-  List<Rule> _rules;
-  Map<String, Iterable<Rule>> _ruleMap;
+  late List<Rule> _rules;
+  late Map<String, Iterable<Rule>> _ruleMap;
 
   /// Returns an unmodifiable list containing the current rules in the original order.
   List<Rule> get rules => List.unmodifiable(_rules);
@@ -37,7 +37,7 @@ class SuffixRules {
   /// [publicsuffix.org](https://publicsuffix.org/list/public_suffix_list.dat).
   /// This includes the `BEGIN PRIVATE` and `END PRIVATE` tags/comments,
   /// which are used by [process] to separate ICANN/IANA rules from private rules.
-  SuffixRules.fromString(String rules)
+  SuffixRules.fromString(String? rules)
       : this.fromList(rules?.split(RegExp(r'[\r\n]+')));
 
   /// Creates a new rule list from a list of rule strings.
@@ -48,7 +48,7 @@ class SuffixRules {
   /// from private rules.
   /// See [publicsuffix.org](https://publicsuffix.org/list/public_suffix_list.dat)
   /// for the rule format.
-  SuffixRules.fromList(List<String> rules) {
+  SuffixRules.fromList(List<String>? rules) {
     rules ??= [];
     var parser = SuffixRulesParser();
     var processed = parser.process(rules);
@@ -61,7 +61,7 @@ class SuffixRules {
   /// [rules] will be validated using a [SuffixRulesParser]
   /// and a [FormatException] will be thrown if one or more
   /// rules are invalid.
-  SuffixRules.fromRules(List<Rule> rules) {
+  SuffixRules.fromRules(List<Rule>? rules) {
     rules ??= [];
     var parser = SuffixRulesParser();
     parser.validate(rules);
@@ -78,7 +78,7 @@ class SuffixRules {
     for (var rule in rules) {
       var lastLabel = rule.labels.substring(rule.labels.lastIndexOf('.') + 1);
       if (map.containsKey(lastLabel)) {
-        map[lastLabel].add(rule);
+        map[lastLabel]!.add(rule);
       } else {
         var list = <Rule>[rule];
         map[lastLabel] = list;
@@ -102,7 +102,7 @@ class Rule {
   /// If the rule is an ICANN/IANA rule.
   final bool isIcann;
 
-  List<String> _parts;
+  late List<String> _parts;
 
   Rule(String rule, {this.isIcann = true})
       : isException = rule.startsWith('!'),
@@ -137,7 +137,7 @@ class Rule {
   int get hashCode {
     var result = 1;
 
-    result = 31 * result + (labels != null ? labels.hashCode : 0);
+    result = 31 * result + labels.hashCode;
     result = 31 * result + (isException ? 1231 : 1237);
     result = 31 * result + (isIcann ? 1231 : 1237);
 
@@ -152,7 +152,7 @@ class Rule {
       return false;
     }
 
-    Rule otherRule = other;
+    var otherRule = other;
     if (labels != otherRule.labels) {
       return false;
     } else if (isException != otherRule.isException) {

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -56,14 +56,14 @@ class DomainUtils {
   ///
   /// Throws a [StateError] if [suffixRules] is null and
   /// [DefaultSuffixRules] has not been initialised.
-  static bool isKnownSuffix(String suffix, {SuffixRules suffixRules}) {
+  static bool isKnownSuffix(String suffix, {SuffixRules? suffixRules}) {
     suffixRules ??= DefaultSuffixRules.rulesOrThrow();
 
     var split = suffix.split('.');
-    var rules = suffixRules.ruleMap[split.last] ?? <String>[];
+    var rules = suffixRules!.ruleMap[split.last] ?? <String>[];
     var isKnown = false;
 
-    for (var rule in rules) {
+    for (var rule in rules as Iterable<dynamic>) {
       if (rule.labels.split('.').length == split.length &&
           rule.matches(suffix)) {
         isKnown = true;

--- a/lib/src/utilities.dart
+++ b/lib/src/utilities.dart
@@ -60,10 +60,10 @@ class DomainUtils {
     suffixRules ??= DefaultSuffixRules.rulesOrThrow();
 
     var split = suffix.split('.');
-    var rules = suffixRules!.ruleMap[split.last] ?? <String>[];
+    var rules = suffixRules.ruleMap[split.last] ?? [];
     var isKnown = false;
 
-    for (var rule in rules as Iterable<dynamic>) {
+    for (var rule in rules) {
       if (rule.labels.split('.').length == split.length &&
           rule.matches(suffix)) {
         isKnown = true;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,12 +6,12 @@ repository: https://www.github.com/komposten/public_suffix
 issue_tracker: https://www.github.com/komposten/public_suffix/issues
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  punycode: ^0.1.0
+  punycode: ^1.0.0
 
 dev_dependencies:
   pedantic: ^1.7.0
   test: ^1.6.10
-  http_multi_server: ^2.2.0 # Here because test uses an earlier version that doesn't compile
+  http_multi_server: ^3.0.0 # Here because test uses an earlier version that doesn't compile

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: public_suffix
 description: A domain parser based on the Public Suffix List, for identifying the root and suffix/TLD of URLs.
-version: 2.0.1
+version: 3.0.0
 homepage: https://www.github.com/komposten/
 repository: https://www.github.com/komposten/public_suffix
 issue_tracker: https://www.github.com/komposten/public_suffix/issues

--- a/test/browser_helper_test.dart
+++ b/test/browser_helper_test.dart
@@ -11,7 +11,7 @@ void main() {
       await SuffixRulesHelper.initDefaultListFromUri(Uri.parse(
           'https://raw.githubusercontent.com/Komposten/public_suffix/master/test/res/public_suffix_list.dat'));
       expect(DefaultSuffixRules.hasInitialised(), isTrue);
-      expect(DefaultSuffixRules.rules.rules, isNotEmpty);
+      expect(DefaultSuffixRules.rules!.rules, isNotEmpty);
     });
 
     test('resourceDoesNotExist_fail', () async {

--- a/test/default_suffix_rules_test.dart
+++ b/test/default_suffix_rules_test.dart
@@ -24,8 +24,8 @@ void main() {
   test('afterInitialising_hasSuffixList', () {
     DefaultSuffixRules.initFromList(['br', 'nom.br']);
     expect(DefaultSuffixRules.rules, isNotNull);
-    expect(DefaultSuffixRules.rules.rules, hasLength(2));
-    expect(DefaultSuffixRules.rules.rules,
+    expect(DefaultSuffixRules.rules!.rules, hasLength(2));
+    expect(DefaultSuffixRules.rules!.rules,
         containsAllInOrder([Rule('br'), Rule('nom.br')]));
   });
 

--- a/test/io_helper_test.dart
+++ b/test/io_helper_test.dart
@@ -13,7 +13,7 @@ void main() {
       await SuffixRulesHelper.initDefaultListFromUri(Uri.parse(
           'https://raw.githubusercontent.com/Komposten/public_suffix/master/test/res/public_suffix_list.dat'));
       expect(DefaultSuffixRules.hasInitialised(), isTrue);
-      expect(DefaultSuffixRules.rules.rules, isNotEmpty);
+      expect(DefaultSuffixRules.rules!.rules, isNotEmpty);
     });
 
     test('resourceDoesNotExist_fail', () async {
@@ -32,7 +32,7 @@ void main() {
     test('validFileUri_initList', () async {
       await SuffixRulesHelper.initDefaultListFromUri(getSuffixListFileUri());
       expect(DefaultSuffixRules.hasInitialised(), isTrue);
-      expect(DefaultSuffixRules.rules.rules, isNotEmpty);
+      expect(DefaultSuffixRules.rules!.rules, isNotEmpty);
     });
   });
 

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -208,12 +208,12 @@ void main() {
       expect(suffix.icannRoot, equals('github'));
       expect(suffix.icannSuffix, equals('io'));
       expect(suffix.icannSubdomain, equals('sub.komposten'));
-      expect(suffix.punyDecoded!.root, equals('komposten'));
-      expect(suffix.punyDecoded!.suffix, equals('github.io'));
-      expect(suffix.punyDecoded!.subdomain, equals('sub'));
-      expect(suffix.punyDecoded!.icannRoot, equals('github'));
-      expect(suffix.punyDecoded!.icannSuffix, equals('io'));
-      expect(suffix.punyDecoded!.icannSubdomain, equals('sub.komposten'));
+      expect(suffix.punyDecoded.root, equals('komposten'));
+      expect(suffix.punyDecoded.suffix, equals('github.io'));
+      expect(suffix.punyDecoded.subdomain, equals('sub'));
+      expect(suffix.punyDecoded.icannRoot, equals('github'));
+      expect(suffix.punyDecoded.icannSuffix, equals('io'));
+      expect(suffix.punyDecoded.icannSubdomain, equals('sub.komposten'));
     });
 
     test('punycodedUrl_punydecodedInstanceHasDecodedData', () {
@@ -222,17 +222,17 @@ void main() {
       expect(suffix.suffix, equals('xn--55qx5d.cn'));
       expect(suffix.root, equals('xn--85x722f'));
       expect(suffix.subdomain, equals('xn--6qq79v'));
-      expect(suffix.punyDecoded!.suffix, equals('公司.cn'));
-      expect(suffix.punyDecoded!.root, equals('食狮'));
-      expect(suffix.punyDecoded!.subdomain, equals('你好'));
+      expect(suffix.punyDecoded.suffix, equals('公司.cn'));
+      expect(suffix.punyDecoded.root, equals('食狮'));
+      expect(suffix.punyDecoded.subdomain, equals('你好'));
     });
 
     test('notPunycodedUrl_punydecodedInstanceHasSameData', () {
       var suffix = PublicSuffix(urlString: 'http://google.co.uk');
       expect(suffix.root, equals('google'));
       expect(suffix.suffix, equals('co.uk'));
-      expect(suffix.punyDecoded!.root, equals('google'));
-      expect(suffix.punyDecoded!.suffix, equals('co.uk'));
+      expect(suffix.punyDecoded.root, equals('google'));
+      expect(suffix.punyDecoded.suffix, equals('co.uk'));
     });
 
     tearDownAll(() => DefaultSuffixRules.dispose());

--- a/test/public_suffix_base_test.dart
+++ b/test/public_suffix_base_test.dart
@@ -208,12 +208,12 @@ void main() {
       expect(suffix.icannRoot, equals('github'));
       expect(suffix.icannSuffix, equals('io'));
       expect(suffix.icannSubdomain, equals('sub.komposten'));
-      expect(suffix.punyDecoded.root, equals('komposten'));
-      expect(suffix.punyDecoded.suffix, equals('github.io'));
-      expect(suffix.punyDecoded.subdomain, equals('sub'));
-      expect(suffix.punyDecoded.icannRoot, equals('github'));
-      expect(suffix.punyDecoded.icannSuffix, equals('io'));
-      expect(suffix.punyDecoded.icannSubdomain, equals('sub.komposten'));
+      expect(suffix.punyDecoded!.root, equals('komposten'));
+      expect(suffix.punyDecoded!.suffix, equals('github.io'));
+      expect(suffix.punyDecoded!.subdomain, equals('sub'));
+      expect(suffix.punyDecoded!.icannRoot, equals('github'));
+      expect(suffix.punyDecoded!.icannSuffix, equals('io'));
+      expect(suffix.punyDecoded!.icannSubdomain, equals('sub.komposten'));
     });
 
     test('punycodedUrl_punydecodedInstanceHasDecodedData', () {
@@ -222,17 +222,17 @@ void main() {
       expect(suffix.suffix, equals('xn--55qx5d.cn'));
       expect(suffix.root, equals('xn--85x722f'));
       expect(suffix.subdomain, equals('xn--6qq79v'));
-      expect(suffix.punyDecoded.suffix, equals('公司.cn'));
-      expect(suffix.punyDecoded.root, equals('食狮'));
-      expect(suffix.punyDecoded.subdomain, equals('你好'));
+      expect(suffix.punyDecoded!.suffix, equals('公司.cn'));
+      expect(suffix.punyDecoded!.root, equals('食狮'));
+      expect(suffix.punyDecoded!.subdomain, equals('你好'));
     });
 
     test('notPunycodedUrl_punydecodedInstanceHasSameData', () {
       var suffix = PublicSuffix(urlString: 'http://google.co.uk');
       expect(suffix.root, equals('google'));
       expect(suffix.suffix, equals('co.uk'));
-      expect(suffix.punyDecoded.root, equals('google'));
-      expect(suffix.punyDecoded.suffix, equals('co.uk'));
+      expect(suffix.punyDecoded!.root, equals('google'));
+      expect(suffix.punyDecoded!.suffix, equals('co.uk'));
     });
 
     tearDownAll(() => DefaultSuffixRules.dispose());
@@ -252,11 +252,11 @@ void main() {
     });
 
     test('normalUrls_parseCorrectly', () {
-      var suffix = PublicSuffix.fromString('http://www.pub.dev');
+      var suffix = PublicSuffix.fromString('http://www.pub.dev')!;
       expect(suffix.suffix, equals('dev'));
       expect(suffix.root, equals('pub'));
 
-      suffix = PublicSuffix.fromString('http://www.komposten.github.io');
+      suffix = PublicSuffix.fromString('http://www.komposten.github.io')!;
       expect(suffix.suffix, equals('github.io'));
       expect(suffix.root, equals('komposten'));
     });
@@ -313,7 +313,7 @@ void main() {
 
     test('normalUrls_parseCorrectly', () {
       var suffix =
-          PublicSuffix.fromUrl(Uri.parse('http://www.komposten.github.io'));
+          PublicSuffix.fromUrl(Uri.parse('http://www.komposten.github.io'))!;
       expect(suffix.suffix, equals('github.io'));
       expect(suffix.root, equals('komposten'));
     });

--- a/test/rule_test.dart
+++ b/test/rule_test.dart
@@ -66,11 +66,6 @@ void main() {
       expect(rule == rule, equals(true));
     });
 
-    test('compareWithNull_false', () {
-      var rule = Rule('ab.cd');
-      expect(rule == null, equals(false));
-    });
-
     test('otherClass_false', () {
       // ignore: unrelated_type_equality_checks
       expect(Rule('ab.cd') == 'ab.cd', equals(false));

--- a/test/suffix_rules_parser_test.dart
+++ b/test/suffix_rules_parser_test.dart
@@ -2,7 +2,7 @@ import 'package:public_suffix/public_suffix.dart';
 import 'package:test/test.dart';
 
 void main() {
-  var parser;
+  late var parser;
 
   setUp(() {
     parser = SuffixRulesParser();


### PR DESCRIPTION
Breaking Changes: The factory constructors PublicSuffix.fromString and PublicSuffix.fromurl hand to be changed to static methods and nndb does not allow a factory to return a null object. This should have minimal impact on existing code ahs the call convention is identical.